### PR TITLE
Fix stats request method tagging

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -170,6 +170,7 @@ type Transport struct {
 
 // RoundTrip instruments the HTTP request/response cycle with metrics.
 func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
+	var method = r.Method
 	var tags = make([]string, 0, len(t.requestTaggers))
 	for _, tagger := range t.requestTaggers {
 		var k, v = tagger(r)
@@ -222,7 +223,7 @@ func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 		statusCode = fmt.Sprintf("%d", errorStatusCode)
 		status = responseStatus(r.Context(), errorStatusCode)
 	}
-	var timerTags = append(tags, fmt.Sprintf("method:%s", r.Method), fmt.Sprintf("status_code:%s", statusCode), fmt.Sprintf("status:%s", status))
+	var timerTags = append(tags, fmt.Sprintf("method:%s", method), fmt.Sprintf("status_code:%s", statusCode), fmt.Sprintf("status:%s", status))
 	xstats.FromRequest(r).Timing(t.requestTime, duration, timerTags...)
 	xstats.FromRequest(r).Histogram(t.bytesIn, float64(bytesRead), tags...)
 	return resp, e


### PR DESCRIPTION
Our transportd lambda component, specifically serverfull-gateway (https://github.com/asecurityteam/serverfull-gateway/blob/master/pkg/http.go#L71) rewrites our requests. This results in any time we use the lambda component we only register POST requests because that is what our lambda transforms the request to. This is incorrect, we should log the original request method and not the transformed one. 

Caveat: 
The lambda component must be declared after the metrics component in the OpenAPI specification/transportd, otherwise the metrics component never has access to the original request.