### PR TITLE
Ignore 'cancelled' misspelling

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -47,6 +47,8 @@ linters-settings:
     # Default is to use a neutral variety of English.
     # Setting locale to US will correct the British spelling of 'colour' to 'color'.
     locale: US
+    ignore-words:
+      - cancelled
   lll:
     # max line length, lines longer will be reported. Default is 120.
     # '\t' is counted as 1 character by default, and can be changed with the tab-width option


### PR DESCRIPTION
Fix linting error for 'cancelled' misspelling by adding to ignore list.