### PR TITLE
Distinguish between client and gateway timeouts

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -91,7 +91,10 @@ func responseStatus(ctx context.Context, statusCode int) string {
 }
 
 func errorToStatusCode(err error) int {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	if errors.Is(err, context.Canceled) {
+		return 499
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
 		return http.StatusGatewayTimeout
 	}
 	return http.StatusBadGateway

--- a/v2/middleware.go
+++ b/v2/middleware.go
@@ -92,7 +92,10 @@ func responseStatus(ctx context.Context, statusCode int) string {
 }
 
 func errorToStatusCode(err error) int {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	if errors.Is(err, context.Canceled) {
+		return 499
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
 		return http.StatusGatewayTimeout
 	}
 	return http.StatusBadGateway


### PR DESCRIPTION
Returns a `499` on `context.Canceled`, rather than transforming it into a `504`.

This logic directly aligns with transportd: https://github.com/asecurityteam/transportd/blob/6ee0c48d988a052a4fbb1aa77469e5a3f39070fb/pkg/errors.go#L32-L39